### PR TITLE
chore: Remove requirement for pnpm "8.6.1" from engines.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "adapter"
   ],
   "engines": {
-    "node": ">=18.12.1 < 20",
-    "pnpm": "8.6.1"
+    "node": ">=18.12.1 < 20"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
chore: Remove requirement for pnpm "8.6.1" from engines.