### PR TITLE
fix(build): exclude peer dependencies from bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       fileName: format => `trpc-nitro-adapter.${format}.js`
     },
     rollupOptions: {
-      external: ['./playground/*.ts'],
+      external: [/^@trpc\/server/, /^ufo/, /^h3/],
       output: {
         sourcemap: true
       }


### PR DESCRIPTION
All peer dependencies were (I presume) accidentally included in the bundled files. Prior to this fix I could not use this library with trpc 10.45, probably because its internals has changed and doesn't work when some of trpc is bundled into this library.

I opted to simply list the modules in the rollup config as there are only 3, but there are also rollup plugins available if you think that's a better way to go.