### PR TITLE
feat: update to tRPC v11.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [tRPC](https://trpc.io) adapter for the [nitro](https://nitro.unjs.io) web ser
 
 ## Requirements
 
-- [tRPC](https://trpc.io) v10._._
+- [tRPC](https://trpc.io) v11._._
 - [nitro](https://nitro.unjs.io) v.2.4.\* or higher
 - [h3](https://github.com/unjs/h3) v.1.6.\* or higher
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "trpc-nitro-adapter",
   "version": "0.7.3",
+  "packageManager": "pnpm@8.6.1",
   "description": "A tRPC adapter for the nitro web server framework.",
   "private": false,
   "repository": {
@@ -41,9 +42,8 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "@trpc/server": "^10.32.0",
-    "h3": "^1.9.0",
-    "ufo": "^1.3.0"
+    "@trpc/server": "^11.1.1",
+    "h3": "^1.15.1"
   },
   "peerDependenciesMeta": {
     "@trpc/server": {
@@ -51,14 +51,11 @@
     },
     "h3": {
       "optional": false
-    },
-    "ufo": {
-      "optional": false
     }
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",
-    "@trpc/server": "^10.32.0",
+    "@trpc/server": "^11.1.1",
     "@types/node": "^20.2.1",
     "@vitest/coverage-v8": "^0.34.4",
     "eslint": "^8.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -9,8 +9,8 @@ devDependencies:
     specifier: ^11.1.6
     version: 11.1.6(rollup@4.14.2)(tslib@2.5.2)(typescript@5.4.5)
   '@trpc/server':
-    specifier: ^10.32.0
-    version: 10.32.0
+    specifier: ^11.1.1
+    version: 11.1.1(typescript@5.4.5)
   '@types/node':
     specifier: ^20.2.1
     version: 20.2.1
@@ -560,8 +560,12 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@trpc/server@10.32.0:
-    resolution: {integrity: sha512-C4HRHpaffw2pekpfNSHQtwlocq6kwAQq48mR9RIsUZGNbjXZbgvBC927vRP6QPAoG+n4oHPWyZ9G1hs3KMcPiw==}
+  /@trpc/server@11.1.1(typescript@5.4.5):
+    resolution: {integrity: sha512-ZjPN3ypBHvGMAlMgeZPrxlRcH/3dn4AK0s5Ph1z+E6uiAvIQVCj7ZoMlXeeBsIy4THGDAk953jHVW2kMnlbb4g==}
+    peerDependencies:
+      typescript: '>=5.7.2'
+    dependencies:
+      typescript: 5.4.5
     dev: true
 
   /@types/estree@1.0.1:
@@ -1173,14 +1177,6 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
-
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1876,7 +1872,7 @@ packages:
       '@rollup/rollup-win32-arm64-msvc': 4.14.2
       '@rollup/rollup-win32-ia32-msvc': 4.14.2
       '@rollup/rollup-win32-x64-msvc': 4.14.2
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:

--- a/src/defineNitroTRPCEventHandler.ts
+++ b/src/defineNitroTRPCEventHandler.ts
@@ -10,26 +10,18 @@ import {
   type AnyRouter,
   type ProcedureType,
   type TRPCError,
-  type inferRouterContext,
-  type inferRouterError
+  type inferRouterContext
 } from '@trpc/server'
 
-import { type TRPCResponse } from '@trpc/server/dist/rpc'
-
-import { type HTTPRequest, type ResponseMeta, resolveHTTPResponse } from '@trpc/server/http'
-
-import { createURL } from 'ufo'
+import { type ResponseMeta, resolveResponse } from '@trpc/server/http'
+import { type TRPCResponse } from '@trpc/server/rpc'
 
 import {
   type EventHandler,
   type EventHandlerRequest,
-  type EventHandlerResponse,
   type H3Event,
   defineEventHandler,
-  readBody,
-  setHeader,
-  isMethod,
-  setResponseStatus
+  toWebRequest
 } from 'h3'
 
 /*****************************************************************************************************************/
@@ -49,11 +41,12 @@ export type CreateContextFn<TRouter extends AnyRouter> = (
 /*****************************************************************************************************************/
 
 export interface ResponseMetaFnPayload<TRouter extends AnyRouter> {
-  data: TRPCResponse<unknown, inferRouterError<TRouter>>[]
+  data: TRPCResponse[]
   ctx?: inferRouterContext<TRouter>
-  paths?: string[]
+  paths?: readonly string[]
   type: ProcedureType | 'unknown'
   errors: TRPCError[]
+  eagerGeneration: boolean
 }
 
 export type ResponseMetaFn<TRouter extends AnyRouter> = (
@@ -66,7 +59,7 @@ export interface OnErrorPayload<TRouter extends AnyRouter> {
   error: TRPCError
   type: ProcedureType | 'unknown'
   path: string | undefined
-  req: HTTPRequest
+  req: Request
   input: unknown
   ctx: undefined | inferRouterContext<TRouter>
 }
@@ -88,7 +81,7 @@ export type NitroRequestHandler = <
   createContext?: CreateContextFn<TRouter>
   responseMeta?: ResponseMetaFn<TRouter>
   onError?: OnErrorFn<TRouter>
-}) => EventHandler<TRequest, EventHandlerResponse<string | undefined>>
+}) => EventHandler<TRequest, Promise<Response>>
 
 /*****************************************************************************************************************/
 
@@ -104,54 +97,51 @@ export const defineNitroTRPCEventHandler: NitroRequestHandler = <TRouter extends
   onError?: OnErrorFn<TRouter>
 }) => {
   return defineEventHandler(async event => {
-    // Extract the request and response objects from the H3 event:
-    const { req: request } = event.node
-
-    // Create a URL object from the request URL:
-    const url = createURL(request.url!)
-
-    // Obtain the URL query parameters:
-    const query = url.searchParams
-
     // Obtain the URL path:
     const path = getPath(event)
 
-    // Construct the native tRPC HTTPReqest object:
-    const req: HTTPRequest = {
-      query,
-      method: request.method || 'GET',
-      headers: request.headers,
-      body: isMethod(event, 'GET') ? null : await readBody(event)
+    // Construct a fetch-compatible Request object for tRPC v11
+    const req = toWebRequest(event)
+
+    // Create wrapper for context function to match v11 API
+    const wrappedCreateContext = async () => {
+      return createContext ? await createContext(event) : undefined
     }
 
-    // Resolve the native tRPC HTTP response:
-    const { status, headers, body } = await resolveHTTPResponse({
+    // Wrapper for response meta to match v11 signature
+    const wrappedResponseMeta = responseMeta
+      ? (opts: ResponseMetaFnPayload<TRouter>) => {
+          // Transform to match our adapter's expected format
+          return responseMeta(opts)
+        }
+      : undefined
+
+    // Wrapper for onError to match v11 signature
+    const wrappedOnError = onError
+      ? (opts: {
+          error: TRPCError
+          type: ProcedureType | 'unknown'
+          path: string | undefined
+          input: unknown
+          ctx: inferRouterContext<TRouter> | undefined
+        }) => {
+          onError({
+            ...opts,
+            req
+          })
+        }
+      : undefined
+
+    // Resolve the tRPC response using the new v11 API:
+    return await resolveResponse({
       router,
       req,
       path,
-      createContext: async () => createContext?.(event),
-      responseMeta,
-      onError: opts => {
-        onError?.({
-          ...opts,
-          req
-        })
-      }
+      error: null,
+      createContext: wrappedCreateContext,
+      responseMeta: wrappedResponseMeta,
+      onError: wrappedOnError
     })
-
-    // Set the status code accordingly:
-    setResponseStatus(event, status)
-
-    // Merge response headers accordingly:
-    headers &&
-      Object.keys(headers).forEach(key => {
-        if (headers[key]) {
-          setHeader(event, key, headers[key]!)
-        }
-      })
-
-    // Return the response body "as is", JSON "stringified":
-    return body
   })
 }
 


### PR DESCRIPTION
- Update imports to use new tRPC v11 module paths
- Update HTTP request handling to use fetch-compatible API
- Update response handling to work with new v11 response format
- Adjust types to match v11 API
- Update README to reflect tRPC v11 requirement
